### PR TITLE
Adds route and tests for updating a contractor

### DIFF
--- a/fix_up/tests.py
+++ b/fix_up/tests.py
@@ -27,3 +27,36 @@ class CreateContractorsTest(BaseTest):
         self.assertEqual(response.data['zip'], '80124')
         self.assertEqual(response.data['category'], 'construction')
         self.assertEqual(response.data['logo'], 'logo.jpg')
+
+class UpdateContractorsTest(BaseTest):
+    def test_it_can_update_a_contractor(self):
+        data = {
+        'name': 'user_1',
+        'email': 'user_1@mail.com',
+        'phone_number': '111111111',
+        'zip': '80124',
+        'category': 'construction',
+        'logo': 'logo.jpg'
+        }
+        response = self.client.post('/api/v1/contractors/', data, format='json')
+        self.assertEqual(Contractors.objects.all()[0].name, 'user_1')
+        self.assertEqual(Contractors.objects.all()[0].email, 'user_1@mail.com')
+
+        # Tests changing just the name
+        update_data = {
+        'name': 'new_name_1'
+        }
+        update_response_1 = self.client.patch(f'/api/v1/contractors/{Contractors.objects.all()[0].id}', update_data, format='json')
+        self.assertEqual(Contractors.objects.all()[0].name, 'new_name_1')
+        self.assertEqual(Contractors.objects.all()[0].email, 'user_1@mail.com')
+        self.assertEqual(update_response_1.status_code, 200)
+
+        # Tests changing just the name again as well as the email
+        update_data = {
+        'name': 'new_name_2',
+        'email': 'new_user_1@mail.com'
+        }
+        update_response_1 = self.client.patch(f'/api/v1/contractors/{Contractors.objects.all()[0].id}', update_data, format='json')
+        self.assertEqual(Contractors.objects.all()[0].name, 'new_name_2')
+        self.assertEqual(Contractors.objects.all()[0].email, 'new_user_1@mail.com')
+        self.assertEqual(update_response_1.status_code, 200)

--- a/fix_up/urls.py
+++ b/fix_up/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
 from .views import CreateContractorView
+from .views import SingleContractorView
 
 urlpatterns = [
-    path('contractors/', CreateContractorView.as_view())
+    path('contractors/', CreateContractorView.as_view()),
+    path('contractors/<int:pk>', SingleContractorView.as_view()),
 ]

--- a/fix_up/views.py
+++ b/fix_up/views.py
@@ -5,3 +5,7 @@ from .serializers import ContractorSerializer
 class CreateContractorView(generics.CreateAPIView):
     queryset = Contractors.objects.all()
     serializer_class = ContractorSerializer
+
+class SingleContractorView(generics.UpdateAPIView):
+    queryset = Contractors.objects.all()
+    serializer_class = ContractorSerializer


### PR DESCRIPTION
## What functionality does this accomplish?
Closes Story #24 

**Description:**
This PR adds functionality to update contractor profile information with:
```
update_data = {
  'name': 'new_name_2',
  'email': 'new_user_1@mail.com'
}
update_response_1 = self.client.patch(f'/api/v1/contractors/{Contractors.objects.all()[0].id}', update_data, format='json')
```

## What did you struggle on to complete?
I struggled to understand the simplicity of Django's rest_framework. [This article](https://medium.com/the-andela-way/creating-a-djangorest-api-using-djangorestframework-part-2-1231fe949795) helped me through, once I realized that the new route had to be added to fix_up/urls.py instead of api/urls.py. 


## Current Test Suite:
### Test Coverage Percentage: x%
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe):

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code
- [x] I have partially tested my code (please explain):
I have not tested any edge cases.

## Helpful Resources:
* [My helpful article mentioned above](https://medium.com/the-andela-way/creating-a-djangorest-api-using-djangorestframework-part-2-1231fe949795). This article helps explain basic CRUD in Django's rest_framework.

@tnodland - I believe this same route could be used for a GET show request? We would just use a GET instead of a PATCH. 
