### PR TITLE
Adds contractor profile show

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 + [Create a User](#create_user)
 + [Create a Contractor](#create_contractor)
++ [See a single Contractor](#see_a_single_contractor)
 + [Update a Contractor](#update_contractor)
 + [Create a Project](#create_project)
 + [See User Show](#see_user_show)
@@ -37,10 +38,10 @@ Example Response:
 ```
 Status: 201 Created
 {
-    "full_name": "user_1_name",
-    "email": "user_1_email@email.com",
-    "phone_number": "3333333",
-    "zip": "98765"
+  "full_name": "user_1_name",
+  "email": "user_1_email@email.com",
+  "phone_number": "3333333",
+  "zip": "98765"
 }
 ```
 
@@ -75,12 +76,36 @@ Example Response:
 ```
 Status: 201 Created
 {
-    "name": "Builder Bob",
-    "email": "test@mail.com",
-    "phone_number": "111111111",
-    "zip": "80124",
-    "category": "construction",
-    "logo": "logo.jpg"
+  "name": "Builder Bob",
+  "email": "test@mail.com",
+  "phone_number": "111111111",
+  "zip": "80124",
+  "category": "construction",
+  "logo": "logo.jpg"
+}
+```
+
+
+# <a name="see_a_single_contractor"></a>See a Single Contractor
+`https://fixup-backend.herokuapp.com/api/v1/contractors/1`
+
+A GET request to `/api/v1/contractors/:id` which takes no body.
+
+Example Request:
+```
+GET https://fixup-backend.herokuapp.com/api/v1/contractors/1
+```
+
+Example Response:
+```
+Status: 200 OK
+{
+  "name": "new_name_1",
+  "email": "new_plumbing@gmail.com",
+  "phone_number": "7205555555",
+  "zip": "80555",
+  "category": "plumbing",
+  "logo": "plumbinglogo.png"
 }
 ```
 
@@ -111,12 +136,12 @@ Example Response:
 ```
 Status: 200 OK
 {
-    "name": "new_name_1",
-    "email": "new_plumbing@gmail.com",
-    "phone_number": "7205555555",
-    "zip": "80555",
-    "category": "plumbing",
-    "logo": "plumbinglogo.png"
+  "name": "new_name_1",
+  "email": "new_plumbing@gmail.com",
+  "phone_number": "7205555555",
+  "zip": "80555",
+  "category": "plumbing",
+  "logo": "plumbinglogo.png"
 }
 ```
 
@@ -147,12 +172,12 @@ Example Response:
 ```
 Status: 201 Created
 {
-    "user_id": 1,
-    "project": {
-        "title": "newly uploaded project",
-        "description": "this is the third project",
-        "picture": "picture.png"
-    }
+  "user_id": 1,
+  "project": {
+    "title": "newly uploaded project",
+    "description": "this is the third project",
+    "picture": "picture.png"
+  }
 }
 ```
 

--- a/fix_up/tests_contractor_crud.py
+++ b/fix_up/tests_contractor_crud.py
@@ -8,27 +8,6 @@ class BaseTest(APITestCase):
 
 class RetrieveContractorTest(BaseTest):
 
-    def test_it_can_get_a_single_contractor_info(self):
-        contractor_1 = Contractor(
-            name='Mario',
-            email='test@mail.com',
-            phone_number='111111111',
-            zip='80124',
-            category='plumbing',
-            logo='logo.jpg'
-        )
-        contractor.save()
-        
-        response = self.client.post(f'/api/v1/contractors/{contractor_1.id}', data, format='json')
-
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(response.data['name'], 'Builder Bob')
-        self.assertEqual(response.data['email'], 'test@mail.com')
-        self.assertEqual(response.data['phone_number'], '111111111')
-        self.assertEqual(response.data['zip'], '80124')
-        self.assertEqual(response.data['category'], 'construction')
-        self.assertEqual(response.data['logo'], 'logo.jpg')
-
     def test_it_can_create_a_contractor(self):
         data = {
         'name': 'Builder Bob',

--- a/fix_up/tests_contractor_crud.py
+++ b/fix_up/tests_contractor_crud.py
@@ -8,6 +8,29 @@ class BaseTest(APITestCase):
 
 class RetrieveContractorTest(BaseTest):
 
+    def test_it_can_retrieve_a_contractor(self):
+        contractor_1 = Contractor(
+            name='Mario',
+            email='test@mail.com',
+            phone_number='111111111',
+            zip='80124',
+            category='plumbing',
+            logo='logo.jpg'
+        )
+        contractor_1.save()
+
+        response = self.client.get(f'/api/v1/contractors/{contractor_1.id}', format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['name'], contractor_1.name)
+        self.assertEqual(response.data['email'], contractor_1.email)
+        self.assertEqual(response.data['phone_number'], contractor_1.phone_number)
+        self.assertEqual(response.data['zip'], contractor_1.zip)
+        self.assertEqual(response.data['category'], contractor_1.category)
+        self.assertEqual(response.data['logo'], contractor_1.logo)
+
+class CreateContractorTest(BaseTest):
+
     def test_it_can_create_a_contractor(self):
         data = {
         'name': 'Builder Bob',

--- a/fix_up/tests_contractor_crud.py
+++ b/fix_up/tests_contractor_crud.py
@@ -6,7 +6,28 @@ from .serializers import ContractorSerializer
 class BaseTest(APITestCase):
     client = APIClient()
 
-class CreateContractorTest(BaseTest):
+class RetrieveContractorTest(BaseTest):
+
+    def test_it_can_get_a_single_contractor_info(self):
+        contractor_1 = Contractor(
+            name='Mario',
+            email='test@mail.com',
+            phone_number='111111111',
+            zip='80124',
+            category='plumbing',
+            logo='logo.jpg'
+        )
+        contractor.save()
+        
+        response = self.client.post(f'/api/v1/contractors/{contractor_1.id}', data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['name'], 'Builder Bob')
+        self.assertEqual(response.data['email'], 'test@mail.com')
+        self.assertEqual(response.data['phone_number'], '111111111')
+        self.assertEqual(response.data['zip'], '80124')
+        self.assertEqual(response.data['category'], 'construction')
+        self.assertEqual(response.data['logo'], 'logo.jpg')
 
     def test_it_can_create_a_contractor(self):
         data = {

--- a/fix_up/views.py
+++ b/fix_up/views.py
@@ -21,7 +21,7 @@ class CreateContractorView(generics.CreateAPIView):
     queryset = Contractor.objects.all()
     serializer_class = ContractorSerializer
 
-class SingleContractorView(generics.UpdateAPIView):
+class SingleContractorView(generics.RetrieveAPIView, generics.UpdateAPIView):
     queryset = Contractor.objects.all()
     serializer_class = ContractorSerializer
 


### PR DESCRIPTION
## What functionality does this accomplish?
Closes Story #5 

**Description:**
This PR adds and tests an endpoint which retrieves a single contractor's information.

Request:
```
GET /api/v1/contractors/{contractor_1.id}
```

Response:
```
{
  "name": "new_name_1",
  "email": "new_plumbing@gmail.com",
  "phone_number": "7205555555",
  "zip": "80555",
  "category": "plumbing",
  "logo": "plumbinglogo.png"
}
```

## What did you struggle on to complete?
The url was the same for Contractors GET and PATCH (both lookup a contractor id). Eventually I figured out this multiple-argument functionality:
```
class SingleContractorView(generics.RetrieveAPIView, generics.UpdateAPIView):
    queryset = Contractor.objects.all()
    serializer_class = ContractorSerializer
```


## Current Test Suite:
### Test Coverage Percentage: x%
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe):

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code
- [x] I have partially tested my code (please explain):

## Helpful Resources:
* [Using multiple generic views for the same route depending on verb](https://stackoverflow.com/questions/55175166/using-generic-createapiview-and-updateapiview-in-the-same-view-in-django-restfra)
