### PR TITLE
Update contractor project on left swipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 + [See Projects By User](#see_projects_by_user)
 + [See Projects By Contractor](#see_projects_by_contractor)
 + [Get Batch of Projects via Contractor ID](#get_batch_of_projects_via_contractor_id)
-
++ [Swiping Updates Contractor Choice](#swiping_updates_contractor_choice)
 
 
 
@@ -476,4 +476,41 @@ Status: 200 OK
     "user_after_picture": null
   }
 ]
+```
+
+
+# <a name="swiping_updates_contractor_choice"></a>Swiping Updates Contractor Choice
+Left Swipe:
+`https://fixup-backend.herokuapp.com/api/v1/contractors/1/projects/1?contractor_choice=1`
+Right Swipe
+`https://fixup-backend.herokuapp.com/api/v1/contractors/1/projects/1?contractor_choice=2`
+
+Left swipe: a PATCH request to `/api/v1/contractors/contractor_id/projects/project_id?contractor_choice=1` which takes no body.
+
+Right swipe: a PATCH request to `/api/v1/contractors/contractor_id/projects/project_id?contractor_choice=2` which takes no body.
+
+Example Swipe LEFT Request:
+```
+PATCH https://fixup-backend.herokuapp.com/api/v1/contractors/1/projects/1?contractor_choice=1
+```
+
+Example Swipe LEFT response:
+```
+Status: 204 Updated
+{
+  "message": "contractor_project contractor_choice updated to 1"
+}
+```
+
+Example Swipe RIGHT Request:
+```
+PATCH https://fixup-backend.herokuapp.com/api/v1/contractors/1/projects/1?contractor_choice=2
+```
+
+Example Swipe RIGHT response:
+```
+Status: 204 Updated
+{
+  "message": "contractor_project contractor_choice updated to 2"
+}
 ```

--- a/fix_up/tests_contractor_crud.py
+++ b/fix_up/tests_contractor_crud.py
@@ -86,8 +86,8 @@ class UpdateContractorTest(BaseTest):
         self.assertEqual(Contractor.objects.all()[0].email, 'new_user_1@mail.com')
         self.assertEqual(update_response_1.status_code, 200)
 
-class SwipeLeftUpdateContractorChoiceTest(BaseTest):
-    def test_it_updates_contractor_choice_from_0_to_1_on_left_swipe(self):
+class SwipeUpdateContractorChoiceTest(BaseTest):
+    def test_it_updates_contractor_choice_on_swipe(self):
 
         user = User(
             full_name='Princess',
@@ -117,6 +117,16 @@ class SwipeLeftUpdateContractorChoiceTest(BaseTest):
         )
         contractor_1.save()
 
+        contractor_2 = Contractor(
+            name='Wario',
+            email='test@mail.com',
+            phone_number='111111111',
+            zip='80124',
+            category='plumbing',
+            logo='logo.jpg'
+        )
+        contractor_2.save()
+
         contractor_project_1 = ContractorProject(
             project=project_1,
             contractor=contractor_1,
@@ -131,12 +141,36 @@ class SwipeLeftUpdateContractorChoiceTest(BaseTest):
         )
         contractor_project_1.save()
 
-        self.assertEqual(ContractorProject.objects.all()[0].contractor_choice, 0)
+        contractor_project_2 = ContractorProject(
+            project=project_1,
+            contractor=contractor_2,
+            contractor_choice=0,
+            user_choice=False,
+            completed=False,
+            seen=False,
+            contractor_before_picture='picture.png',
+            contractor_after_picture='picture.png',
+            user_rating=5,
+            contractor_rating=5
+        )
+        contractor_project_2.save()
 
-        data = {
-            'contractor_choice': 1
-        }
-        update_response = self.client.patch(f'/api/v1/contractors/{Contractor.objects.all()[0].id}/projects/{Project.objects.all()[0].id}', data, format='json')
+        self.assertEqual(ContractorProject.objects.filter(contractor_id=contractor_1.id)[0].contractor_choice, 0)
+        self.assertEqual(ContractorProject.objects.filter(contractor_id=contractor_2.id)[0].contractor_choice, 0)
 
-        self.assertEqual(update_response.data['message'], 'contractor_project contractor_choice updated to 1')
-        self.assertEqual(update_response.status_code, 204)
+        #### MARIO
+        #### Tests updating contractor_project_1.contractor_choice to 1 (LEFT swipe)
+        update_response_1 = self.client.patch(f'/api/v1/contractors/{contractor_1.id}/projects/{Project.objects.all()[0].id}?contractor_choice=1', format='json')
+        self.assertEqual(ContractorProject.objects.filter(contractor_id=contractor_1.id)[0].contractor_choice, 1)
+        self.assertEqual(ContractorProject.objects.filter(contractor_id=contractor_2.id)[0].contractor_choice, 0)
+        self.assertEqual(update_response_1.data['message'], 'contractor_project contractor_choice updated to 1')
+        self.assertEqual(update_response_1.status_code, 204)
+
+        #### WARIO
+        #### Tests updating contractor_project_2.contractor_choice to 2 (RIGHT swipe)
+        update_response_2 = self.client.patch(f'/api/v1/contractors/{contractor_2.id}/projects/{Project.objects.all()[0].id}?contractor_choice=2', format='json')
+        self.assertEqual(ContractorProject.objects.filter(contractor_id=contractor_1.id)[0].contractor_choice, 1)
+        self.assertEqual(ContractorProject.objects.filter(contractor_id=contractor_2.id)[0].contractor_choice, 2)
+        self.assertEqual(ContractorProject.objects.all()[0].contractor_choice, 1)
+        self.assertEqual(update_response_2.data['message'], 'contractor_project contractor_choice updated to 2')
+        self.assertEqual(update_response_2.status_code, 204)

--- a/fix_up/tests_contractor_crud.py
+++ b/fix_up/tests_contractor_crud.py
@@ -1,6 +1,9 @@
 from rest_framework.test import APITestCase, APIClient, APIRequestFactory
 from rest_framework.views import status
+from .models import User
+from .models import Project
 from .models import Contractor
+from .models import ContractorProject
 from .serializers import ContractorSerializer
 
 class BaseTest(APITestCase):
@@ -82,3 +85,58 @@ class UpdateContractorTest(BaseTest):
         self.assertEqual(Contractor.objects.all()[0].name, 'new_name_2')
         self.assertEqual(Contractor.objects.all()[0].email, 'new_user_1@mail.com')
         self.assertEqual(update_response_1.status_code, 200)
+
+class SwipeLeftUpdateContractorChoiceTest(BaseTest):
+    def test_it_updates_contractor_choice_from_0_to_1_on_left_swipe(self):
+
+        user = User(
+            full_name='Princess',
+            email='another_castle@mail.com',
+            phone_number='1234566',
+            zip='12345'
+        )
+        user.save()
+
+        project_1 = Project(
+            user=user,
+            title='project_1',
+            description='this is the first project',
+            category='plumbing',
+            user_before_picture='picture.png',
+            user_after_picture='picture.png'
+        )
+        project_1.save()
+
+        contractor_1 = Contractor(
+            name='Mario',
+            email='test@mail.com',
+            phone_number='111111111',
+            zip='80124',
+            category='plumbing',
+            logo='logo.jpg'
+        )
+        contractor_1.save()
+
+        contractor_project_1 = ContractorProject(
+            project=project_1,
+            contractor=contractor_1,
+            contractor_choice=0,
+            user_choice=False,
+            completed=False,
+            seen=False,
+            contractor_before_picture='picture.png',
+            contractor_after_picture='picture.png',
+            user_rating=5,
+            contractor_rating=5
+        )
+        contractor_project_1.save()
+
+        self.assertEqual(ContractorProject.objects.all()[0].contractor_choice, 0)
+
+        data = {
+            'contractor_choice': 1
+        }
+        update_response = self.client.patch(f'/api/v1/contractors/{Contractor.objects.all()[0].id}/projects/{Project.objects.all()[0].id}', data, format='json')
+
+        self.assertEqual(update_response.data['message'], 'contractor_project contractor_choice updated to 1')
+        self.assertEqual(update_response.status_code, 204)

--- a/fix_up/tests_project_crud.py
+++ b/fix_up/tests_project_crud.py
@@ -202,10 +202,9 @@ class CreateProjectTest(BaseTest):
             'user_before_picture': 'picture.png'
         }
 
-        response = self.client.post('/api/v1/users/2/projects', data, format='json')
-
+        response = self.client.post(f'/api/v1/users/{user_1.id}/projects', data, format='json')
+#
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['project']['title'], 'project_numero_tres')
         self.assertEqual(response.data['project']['description'], 'this is the third project')
         self.assertEqual(response.data['project']['picture'], 'picture.png')
-

--- a/fix_up/urls.py
+++ b/fix_up/urls.py
@@ -7,7 +7,7 @@ from .views import SingleProjectView
 from .views import ListProjectsByContractor
 from .views import ListProjectsByUser
 from .views import ListProjectBatchView
-from .views import SwipeLeftUpdateContractorChoiceView
+from .views import SwipeUpdateContractorChoiceView
 
 urlpatterns = [
     path('contractors/', CreateContractorView.as_view()),
@@ -18,5 +18,5 @@ urlpatterns = [
     path('contractors/<int:contractor_id>/projects', ListProjectsByContractor.as_view()),
     path('users/<int:user_id>/projects', ListProjectsByUser.as_view()),
     path('projects', ListProjectBatchView.as_view()),
-    path('contractors/<int:contractor_id>/projects/<int:project_id>', SwipeLeftUpdateContractorChoiceView.as_view())
+    path('contractors/<int:contractor_id>/projects/<int:project_id>', SwipeUpdateContractorChoiceView.as_view())
 ]

--- a/fix_up/urls.py
+++ b/fix_up/urls.py
@@ -7,6 +7,7 @@ from .views import SingleProjectView
 from .views import ListProjectsByContractor
 from .views import ListProjectsByUser
 from .views import ListProjectBatchView
+from .views import SwipeLeftUpdateContractorChoiceView
 
 urlpatterns = [
     path('contractors/', CreateContractorView.as_view()),
@@ -16,5 +17,6 @@ urlpatterns = [
     path('projects/<int:pk>', SingleProjectView.as_view()),
     path('contractors/<int:contractor_id>/projects', ListProjectsByContractor.as_view()),
     path('users/<int:user_id>/projects', ListProjectsByUser.as_view()),
-    path('projects', ListProjectBatchView.as_view())
+    path('projects', ListProjectBatchView.as_view()),
+    path('contractors/<int:contractor_id>/projects/<int:project_id>', SwipeLeftUpdateContractorChoiceView.as_view())
 ]

--- a/fix_up/views.py
+++ b/fix_up/views.py
@@ -114,12 +114,11 @@ class ListProjectBatchView(generics.ListAPIView):
 
         return projects
 
-class SwipeLeftUpdateContractorChoiceView(APIView):
+class SwipeUpdateContractorChoiceView(APIView):
     renderer_classes = [JSONRenderer]
     def patch(self, request, **kwargs):
-        ContractorProject.objects.filter(contractor_id=self.kwargs['contractor_id'], project_id=self.kwargs['project_id']).update(contractor_choice=1)
-
+        target = ContractorProject.objects.filter(contractor_id=self.kwargs['contractor_id'], project_id=self.kwargs['project_id'])
+        target.update(contractor_choice=int(self.request.query_params["contractor_choice"]))
         return Response({
-            'message': 'contractor_project contractor_choice updated to 1'
+            'message': f'contractor_project contractor_choice updated to {int(self.request.query_params["contractor_choice"])}'
         }, status=204)
-        

--- a/fix_up/views.py
+++ b/fix_up/views.py
@@ -113,3 +113,13 @@ class ListProjectBatchView(generics.ListAPIView):
         ContractorProject.objects.create(contractor=contractor, project=projects[9])
 
         return projects
+
+class SwipeLeftUpdateContractorChoiceView(APIView):
+    renderer_classes = [JSONRenderer]
+    def patch(self, request, **kwargs):
+        ContractorProject.objects.filter(contractor_id=self.kwargs['contractor_id'], project_id=self.kwargs['project_id']).update(contractor_choice=1)
+
+        return Response({
+            'message': 'contractor_project contractor_choice updated to 1'
+        }, status=204)
+        


### PR DESCRIPTION
## What functionality does this accomplish?
Closes Story #21 
Closes Story #22 

**Description:**
This PR adds tests and functionality for when a contractor swipes left or right on a project.

A LEFT or RIGHT swipe will find the contractor_project which joins the contractor and project id's in the url. The url also contains a `contractor_choice` param which is used to update the field in the filtered contractor_project.

## What did you struggle on to complete?
I had major struggles in testing. I eventually figured out that by updating an indexed contractor_project, that contractor_project changes index position. 

My solution was to reference objects by filtering according to contractor_id, rather than by their original index.


## Current Test Suite:
### Test Coverage Percentage: x%
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe):

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code
- [x] I have partially tested my code

## Helpful Resources:
* None
