### PR TITLE
Add seen to contractors projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,13 +297,28 @@ Example Response:
 ```
 Status: 200 OK
 [
-  {
-    "title": "Broken Pipe",
-    "description": "A pipe in my bathroom is leaky",
-    "category": "plumbing",
-    "user_before_picture": "brokenpipe.png",
-    "user_after_picture": null
-  }
+	{
+		"project": {
+			"id": 1,
+			"title": "Broken Pipe",
+			"description": "A pipe in my bathroom is leaky",
+			"category": "plumbing",
+			"user_before_picture": "brokenpipe.png",
+			"user_after_picture": null
+		},
+		"seen": false
+	},
+	{
+		"project": {
+			"id": 1,
+			"title": "Broken Pipe",
+			"description": "A pipe in my bathroom is leaky",
+			"category": "plumbing",
+			"user_before_picture": "brokenpipe.png",
+			"user_after_picture": null
+		},
+		"seen": false
+	},
 ]
 ```
 

--- a/fix_up/tests_project_crud.py
+++ b/fix_up/tests_project_crud.py
@@ -178,11 +178,15 @@ class ProjectCrudTest(BaseTest):
         contractor_project_4.save()
 
         response = self.client.get(f'/api/v1/contractors/{contractor_1.id}/projects', format='json')
-
+        # import code; code.interact(local=dict(globals(), **locals()))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]['id'], project_2.id)
         self.assertEqual(response.data[1]['title'], project_1.title)
-        self.assertEqual(response.data[0]['title'], project_2.title)
+        self.assertEqual(response.data[0]['description'], project_2.description)
+        self.assertEqual(response.data[0]['category'], project_2.category)
+        self.assertEqual(response.data[0]['user_before_picture'], project_2.user_before_picture)
+        self.assertEqual(response.data[0]['user_after_picture'], project_2.user_after_picture)
 
 class CreateProjectTest(BaseTest):
 

--- a/fix_up/tests_project_crud.py
+++ b/fix_up/tests_project_crud.py
@@ -127,7 +127,7 @@ class ProjectCrudTest(BaseTest):
             contractor_choice=0,
             user_choice=True,
             completed=False,
-            seen=False,
+            seen=True,
             contractor_before_picture='picture.png',
             contractor_after_picture='picture.png',
             user_rating=5,
@@ -141,7 +141,7 @@ class ProjectCrudTest(BaseTest):
             contractor_choice=0,
             user_choice=False,
             completed=False,
-            seen=False,
+            seen=True,
             contractor_before_picture='picture.png',
             contractor_after_picture='picture.png',
             user_rating=5,
@@ -178,15 +178,16 @@ class ProjectCrudTest(BaseTest):
         contractor_project_4.save()
 
         response = self.client.get(f'/api/v1/contractors/{contractor_1.id}/projects', format='json')
-        # import code; code.interact(local=dict(globals(), **locals()))
+
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 2)
-        self.assertEqual(response.data[0]['id'], project_2.id)
-        self.assertEqual(response.data[1]['title'], project_1.title)
-        self.assertEqual(response.data[0]['description'], project_2.description)
-        self.assertEqual(response.data[0]['category'], project_2.category)
-        self.assertEqual(response.data[0]['user_before_picture'], project_2.user_before_picture)
-        self.assertEqual(response.data[0]['user_after_picture'], project_2.user_after_picture)
+        self.assertEqual(response.data[0]['project']['id'], project_2.id)
+        self.assertEqual(response.data[1]['project']['title'], project_1.title)
+        self.assertEqual(response.data[0]['project']['description'], project_2.description)
+        self.assertEqual(response.data[0]['project']['category'], project_2.category)
+        self.assertEqual(response.data[0]['project']['user_before_picture'], project_2.user_before_picture)
+        self.assertEqual(response.data[0]['project']['user_after_picture'], project_2.user_after_picture)
+        self.assertEqual(response.data[0]['seen'], contractor_project_3.seen)
 
 class CreateProjectTest(BaseTest):
 

--- a/fix_up/views.py
+++ b/fix_up/views.py
@@ -31,15 +31,27 @@ class SingleProjectView(generics.RetrieveAPIView):
     serializer_class = ProjectSerializer
 
 # Ideally we would access query_params for user_choice, but I hard-coded it for now
-class ListProjectsByContractor(generics.ListAPIView):
-    serializer_class = ProjectSerializer
-    def get_queryset(self):
+class ListProjectsByContractor(APIView):
+    renderer_classes = [JSONRenderer]
+    def get(self, request, **kwargs):
         contractor_filtered = ContractorProject.objects.filter(contractor=self.kwargs["contractor_id"])
         user_choice_filtered = contractor_filtered.filter(user_choice=True)
         accumulator = []
         for element in user_choice_filtered:
-            accumulator.append(element.project)
-        return accumulator
+            accumulator.append(
+                {
+                    "project": {
+                        "id": element.project.id,
+                        "title": element.project.title,
+                        "description": element.project.description,
+                        "category": element.project.category,
+                        "user_before_picture": element.project.user_before_picture,
+                        "user_after_picture": element.project.user_after_picture
+                    },
+                    "seen": element.seen
+                }
+            )
+        return Response(accumulator)
 
 #### Users
 class CreateUserView(generics.CreateAPIView):

--- a/fix_up/views.py
+++ b/fix_up/views.py
@@ -36,7 +36,10 @@ class ListProjectsByContractor(generics.ListAPIView):
     def get_queryset(self):
         contractor_filtered = ContractorProject.objects.filter(contractor=self.kwargs["contractor_id"])
         user_choice_filtered = contractor_filtered.filter(user_choice=True)
-        return [element.project for element in user_choice_filtered]
+        accumulator = []
+        for element in user_choice_filtered:
+            accumulator.append(element.project)
+        return accumulator
 
 #### Users
 class CreateUserView(generics.CreateAPIView):


### PR DESCRIPTION
## What functionality does this accomplish?
Closes Story #64 

**Description:**
This PR adds the `seen` boolean to the project dictionary returned by contractor.
```
Example Request:
```
GET https://fixup-backend.herokuapp.com/api/v1/contractors/1/projects
```

Example Response:
```
Status: 200 OK
[
	{
		"project": {
			"id": 1,
			"title": "Broken Pipe",
			"description": "A pipe in my bathroom is leaky",
			"category": "plumbing",
			"user_before_picture": "brokenpipe.png",
			"user_after_picture": null
		},
		"seen": false
	},
	{
		"project": {
			"id": 1,
			"title": "Broken Pipe",
			"description": "A pipe in my bathroom is leaky",
			"category": "plumbing",
			"user_before_picture": "brokenpipe.png",
			"user_after_picture": null
		},
		"seen": false
	},
]
``` 

## What did you struggle on to complete?
I had to rearrange my one-liner for-loop into a multi liner in order to build a new dictionary.


## Current Test Suite:
### Test Coverage Percentage: x%
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe):

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code
- [x] I have partially tested my code (please explain):

## Helpful Resources:
* None
