### PR TITLE
Patch seen boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 + [Get Batch of Projects via Contractor ID](#get_batch_of_projects_via_contractor_id)
 + [Swiping Updates Contractor Choice](#swiping_updates_contractor_choice)
 + [User Selects Contractor](#update_user_choice)
++ [User Sees Project For First Time](#update_seen_boolean)
 
 
 
@@ -124,7 +125,7 @@ A PATCH request to `/api/v1/contractors/:id` takes a body with an object of any 
 
 Example Request:
 ```
-POST https://fixup-backend.herokuapp.com/api/v1/contractors/1
+PATCH https://fixup-backend.herokuapp.com/api/v1/contractors/1
 
 Body; raw, JSON(application/json):
 {
@@ -588,5 +589,28 @@ Example Response:
     "phone_number": "3035555555",
     "zip": "80555"
   }
+}
+```
+
+# <a name="update_seen_boolean"></a>User Sees Project For First Time
+`https://fixup-backend.herokuapp.com/api/v1/contractors/1/projects/1`
+
+A PATCH request to `/api/v1/contractors/:id/projects/:id` which takes a body.
+
+Example Request:
+```
+PATCH https://fixup-backend.herokuapp.com/api/v1/contractors/1/projects/1
+
+Body; raw, JSON(application/json):
+{
+  "seen": "True"
+}
+```
+
+Example Response:
+```
+Status: 200 OK
+{
+  "message": "Contractor's project marked as 'seen'"
 }
 ```

--- a/fix_up/tests_updating_contractorprojects.py
+++ b/fix_up/tests_updating_contractorprojects.py
@@ -238,3 +238,85 @@ class SwipeUpdateContractorChoiceTest(BaseTest):
         self.assertEqual(ContractorProject.objects.filter(contractor_id=contractor_2.id)[0].contractor_choice, 2)
         self.assertEqual(update_response_2.data['message'], 'contractor_project contractor_choice updated to 2')
         self.assertEqual(update_response_2.status_code, 200)
+
+class UpdateSeenTest(BaseTest):
+    def test_it_updates_seen_boolean(self):
+
+        user = User(
+            full_name='Princess',
+            email='another_castle@mail.com',
+            phone_number='1234566',
+            zip='12345'
+        )
+        user.save()
+
+        project_1 = Project(
+            user=user,
+            title='project_1',
+            description='this is the first project',
+            category='plumbing',
+            user_before_picture='picture.png',
+            user_after_picture='picture.png'
+        )
+        project_1.save()
+
+        contractor_1 = Contractor(
+            name='Mario',
+            email='test@mail.com',
+            phone_number='111111111',
+            zip='80124',
+            category='plumbing',
+            logo='logo.jpg'
+        )
+        contractor_1.save()
+
+        contractor_2 = Contractor(
+            name='Wario',
+            email='test@mail.com',
+            phone_number='111111111',
+            zip='80124',
+            category='plumbing',
+            logo='logo.jpg'
+        )
+        contractor_2.save()
+
+        contractor_project_1 = ContractorProject(
+            project=project_1,
+            contractor=contractor_1,
+            contractor_choice=0,
+            user_choice=False,
+            completed=False,
+            seen=False,
+            contractor_before_picture='picture.png',
+            contractor_after_picture='picture.png',
+            user_rating=5,
+            contractor_rating=5
+        )
+        contractor_project_1.save()
+
+        contractor_project_2 = ContractorProject(
+            project=project_1,
+            contractor=contractor_2,
+            contractor_choice=0,
+            user_choice=False,
+            completed=False,
+            seen=False,
+            contractor_before_picture='picture.png',
+            contractor_after_picture='picture.png',
+            user_rating=5,
+            contractor_rating=5
+        )
+        contractor_project_2.save()
+
+        self.assertEqual(ContractorProject.objects.filter(contractor_id=contractor_1.id)[0].seen, False)
+        self.assertEqual(ContractorProject.objects.filter(contractor_id=contractor_2.id)[0].seen, False)
+
+        #### Tests updating contractor_project_1.seen to False
+        data = {
+            "seen": True
+        }
+        update_response_1 = self.client.patch(f'/api/v1/contractors/{contractor_1.id}/projects/{Project.objects.all()[0].id}', data, format='json')
+        self.assertEqual(ContractorProject.objects.filter(contractor_id=contractor_1.id)[0].seen, True)
+        self.assertEqual(ContractorProject.objects.filter(contractor_id=contractor_2.id)[0].seen, False)
+        self.assertEqual(update_response_1.data['message'], "Contractor's project marked as 'seen'")
+        self.assertEqual(update_response_1.status_code, 200)

--- a/fix_up/views.py
+++ b/fix_up/views.py
@@ -156,7 +156,7 @@ class SwipeUpdateContractorChoiceView(APIView):
                 'message': f'contractor_project contractor_choice updated to {int(request.data["contractor_choice"])}'
             })
         elif 'seen' in request.data.keys():
-            target.update(seen=int(request.data["seen"]))
+            target.update(seen=request.data["seen"])
             return Response({
                 'message': "Contractor's project marked as 'seen'"
             })

--- a/fix_up/views.py
+++ b/fix_up/views.py
@@ -150,11 +150,16 @@ class SwipeUpdateContractorChoiceView(APIView):
     renderer_classes = [JSONRenderer]
     def patch(self, request, **kwargs):
         target = ContractorProject.objects.filter(contractor_id=self.kwargs['contractor_id'], project_id=self.kwargs['project_id'])
-        target.update(contractor_choice=int(request.data["contractor_choice"]))
-
-        return Response({
-            'message': f'contractor_project contractor_choice updated to {int(request.data["contractor_choice"])}'
-        })
+        if 'contractor_choice' in request.data.keys():
+            target.update(contractor_choice=int(request.data["contractor_choice"]))
+            return Response({
+                'message': f'contractor_project contractor_choice updated to {int(request.data["contractor_choice"])}'
+            })
+        elif 'seen' in request.data.keys():
+            target.update(seen=int(request.data["seen"]))
+            return Response({
+                'message': "Contractor's project marked as 'seen'"
+            })
 
 class UpdateUserChoiceView(APIView):
     renderer_classes = [JSONRenderer]


### PR DESCRIPTION
## What functionality does this accomplish?
Closes Story #[68](https://github.com/james-cape/fixup_backend/issues/68)

**Description:**
Adds ability to update 'seen' boolean on contractor_projects via PATCH.

### User Sees Project For First Time
A PATCH request to `/api/v1/contractors/:id/projects/:id` which takes a body.

Example Request:
```
PATCH https://fixup-backend.herokuapp.com/api/v1/contractors/1/projects/1

Body; raw, JSON(application/json):
{
  "seen": "True"
}
```

Example Response:
```
Status: 200 OK
{
  "message": "Contractor's project marked as 'seen'"
}
```

## What did you struggle on to complete?
To test whether a dictionary contains a key:
```
if 'contractor_choice' in request.data.keys():
```


## Current Test Suite:
### Test Coverage Percentage: x%
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe):

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code
- [x] I have partially tested my code (please explain):

## Helpful Resources:
* None
