### PR TITLE
Add id to responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 + [Create a Project](#create_project)
 + [See User Show](#see_user_show)
 + [See Project Show](#see_project_show)
++ [Update a Project](#update_a_project)
 + [See Projects By User](#see_projects_by_user)
 + [See Projects By Contractor](#see_projects_by_contractor)
 + [Get Batch of Projects via Contractor ID](#get_batch_of_projects_via_contractor_id)
@@ -237,6 +238,37 @@ GET https://fixup-backend.herokuapp.com/api/v1/projects/1
 
 Example Response:
 (See last element for an example of a user's project which a contractor has swiped right on)
+```
+Status: 200 OK
+{
+  "title": "Broken Pipe",
+  "description": "A pipe in my bathroom is leaky",
+  "category": "plumbing",
+  "user_before_picture": "brokenpipe.png",
+  "user_after_picture": null
+}
+```
+
+
+# <a name="update_a_project"></a>Update a Project
+`https://fixup-backend.herokuapp.com/api/v1/projects/1`
+
+A PATCH request to `/api/v1/projects/:id` which takes a body.
+
+Example Request:
+```
+PATCH https://fixup-backend.herokuapp.com/api/v1/projects/1
+{
+  "id": 1,
+  "title": "I changed the title",
+  "description": "I changed the description",
+  "category": "plumbing",
+  "user_before_picture": "brokenpipe.png",
+  "user_after_picture": null
+}
+```
+
+Example Response:
 ```
 Status: 200 OK
 {

--- a/fix_up/serializers.py
+++ b/fix_up/serializers.py
@@ -7,17 +7,17 @@ from .models import ContractorProject
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('full_name', 'email', 'phone_number', 'zip')
+        fields = ('id', 'full_name', 'email', 'phone_number', 'zip')
 
 class ContractorSerializer(serializers.ModelSerializer):
     class Meta:
         model = Contractor
-        fields = ('name', 'email', 'phone_number', 'zip', 'category', 'logo')
+        fields = ('id', 'name', 'email', 'phone_number', 'zip', 'category', 'logo')
 
 class ContractorProjectSerializer(serializers.ModelSerializer):
     class Meta:
         model = ContractorProject
-        fields = ('project', 'contractor', 'contractor_choice', 'user_choice', 'seen', 'completed', 'contractor_before_picture', 'contractor_after_picture', 'user_rating', 'contractor_rating')
+        fields = ('id', 'project', 'contractor', 'contractor_choice', 'user_choice', 'seen', 'completed', 'contractor_before_picture', 'contractor_after_picture', 'user_rating', 'contractor_rating')
 
 class ProjectSerializer(serializers.ModelSerializer):
     class Meta:

--- a/fix_up/tests_project_crud.py
+++ b/fix_up/tests_project_crud.py
@@ -215,3 +215,34 @@ class CreateProjectTest(BaseTest):
         self.assertEqual(response.data['project']['title'], 'project_numero_tres')
         self.assertEqual(response.data['project']['description'], 'this is the third project')
         self.assertEqual(response.data['project']['picture'], 'picture.png')
+
+class UpdateProjectTest(BaseTest):
+
+    def test_it_can_update_a_project(self):
+        user_1 = User(
+            full_name='Princess',
+            email='another_castle@mail.com',
+            phone_number='1234566',
+            zip='12345'
+        )
+        user_1.save()
+
+        project_1 = Project(
+            user=user_1,
+            title='project_numero_uno',
+            description='this is the first project',
+            category='plumbing',
+            user_before_picture='picture.png'
+        )
+        project_1.save()
+
+        data = {
+            'title': 'I changed the title',
+            'description': 'I changed the description'
+        }
+
+        response = self.client.patch(f'/api/v1/projects/{project_1.id}', data, format='json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['title'], 'I changed the title')
+        self.assertEqual(response.data['description'], 'I changed the description')
+        self.assertEqual(response.data['category'], 'plumbing')

--- a/fix_up/tests_updating_contractorprojects.py
+++ b/fix_up/tests_updating_contractorprojects.py
@@ -92,6 +92,7 @@ class UserSelectsContractorTest(BaseTest):
         self.assertEqual(ContractorProject.objects.filter(contractor_id=contractor_2.id)[0].user_choice, False)
         self.assertEqual(update_response_1.data['message'], "You've been Fixed Up!")
         self.assertEqual(update_response_1.data['contractor'], {
+            "id": contractor_1.id,
             "name": contractor_1.name,
             "email": contractor_1.email,
             "phone_number": contractor_1.phone_number,
@@ -100,6 +101,7 @@ class UserSelectsContractorTest(BaseTest):
             "logo": contractor_1.logo
         })
         self.assertEqual(update_response_1.data['project'], {
+            "id": project_1.id,
             "title": project_1.title,
             "description": project_1.description,
             "category": project_1.category,
@@ -107,6 +109,7 @@ class UserSelectsContractorTest(BaseTest):
             "user_after_picture": project_1.user_after_picture
         })
         self.assertEqual(update_response_1.data['user'], {
+            "id": user.id,
             "full_name": user.full_name,
             "email": user.email,
             "phone_number": user.phone_number,
@@ -124,6 +127,7 @@ class UserSelectsContractorTest(BaseTest):
         self.assertEqual(ContractorProject.objects.filter(contractor_id=contractor_2.id)[0].user_choice, True)
         self.assertEqual(update_response_2.data['message'], "You've been Fixed Up!")
         self.assertEqual(update_response_2.data['contractor'], {
+            "id": contractor_2.id,
             "name": contractor_2.name,
             "email": contractor_2.email,
             "phone_number": contractor_2.phone_number,
@@ -132,6 +136,7 @@ class UserSelectsContractorTest(BaseTest):
             "logo": contractor_2.logo
         })
         self.assertEqual(update_response_2.data['project'], {
+            "id": project_1.id,
             "title": project_1.title,
             "description": project_1.description,
             "category": project_1.category,
@@ -139,6 +144,7 @@ class UserSelectsContractorTest(BaseTest):
             "user_after_picture": project_1.user_after_picture
         })
         self.assertEqual(update_response_2.data['user'], {
+            "id": user.id,
             "full_name": user.full_name,
             "email": user.email,
             "phone_number": user.phone_number,

--- a/fix_up/views.py
+++ b/fix_up/views.py
@@ -173,6 +173,7 @@ class UpdateUserChoiceView(APIView):
         return Response({
             'message': "You've been Fixed Up!",
             'contractor': {
+                "id": contractor.id,
                 "name": contractor.name,
                 "email": contractor.email,
                 "phone_number": contractor.phone_number,
@@ -181,6 +182,7 @@ class UpdateUserChoiceView(APIView):
                 "logo": contractor.logo
             },
             "project": {
+                "id": project.id,
                 "title": project.title,
                 "description": project.description,
                 "category": project.category,
@@ -188,6 +190,7 @@ class UpdateUserChoiceView(APIView):
                 "user_after_picture": project.user_after_picture
             },
             "user": {
+                "id": user.id,
                 "full_name": user.full_name,
                 "email": user.email,
                 "phone_number": user.phone_number,

--- a/fix_up/views.py
+++ b/fix_up/views.py
@@ -26,7 +26,7 @@ class SingleContractorView(generics.RetrieveAPIView, generics.UpdateAPIView):
     serializer_class = ContractorSerializer
 
 #### Projects
-class SingleProjectView(generics.RetrieveAPIView):
+class SingleProjectView(generics.RetrieveAPIView, generics.UpdateAPIView):
     queryset = Project.objects.all()
     serializer_class = ProjectSerializer
 


### PR DESCRIPTION
## What functionality does this accomplish?
**Description:**
Adds id to all serializers and objects being returned

## What did you struggle on to complete?
None


## Current Test Suite:
### Test Coverage Percentage: x%
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe):

## Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code
- [x] I have partially tested my code (please explain):

## Helpful Resources:
* None
